### PR TITLE
Support remote taring

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,1 +1,7 @@
 import Config
+
+config :flow,
+  monitors: [
+    %{pin: 24, log_id: "cba36eac-41bd-4230-a89b-4bf694dd8980"}
+  ],
+  socket_url: "ws://localhost:4000/socket/websocket"

--- a/lib/flow/backend.ex
+++ b/lib/flow/backend.ex
@@ -105,6 +105,12 @@ defmodule Flow.Backend do
     {:ok, state}
   end
 
+  def handle_message(topic, "tare", _payload, _transport, state) do
+    Logger.info("Received tare event")
+    Flow.Scale.tare()
+    {:ok, state}
+  end
+
   def handle_message(topic, event, payload, _transport, state) do
     Logger.warn("Unkonwn message on topic #{topic}: #{event} #{inspect(payload)}")
     {:ok, state}

--- a/lib/flow/backend.ex
+++ b/lib/flow/backend.ex
@@ -106,7 +106,7 @@ defmodule Flow.Backend do
   end
 
   def handle_message(topic, "tare", _payload, _transport, state) do
-    Logger.info("Received tare event")
+    Logger.info("Received tare event on #{topic}")
     Flow.Scale.tare()
     {:ok, state}
   end

--- a/lib/flow/scale.ex
+++ b/lib/flow/scale.ex
@@ -21,6 +21,15 @@ defmodule Flow.Scale do
     {:noreply, Map.put(state, :py_pid, py_pid)}
   end
 
+  def tare do
+    GenServer.cast(__MODULE__, :tare)
+  end
+
+  def handle_cast(:tare, %{py_pid: pid} = state) do
+    :python.call(pid, :scale, :tare, [])
+    {:noreply, state}
+  end
+
   def handle_info(:get_measurement, %{py_pid: pid, log_id: log_id} = state) do
     value = get_measurement(pid)
     value = max(0, value)

--- a/lib/flow/scale.ex
+++ b/lib/flow/scale.ex
@@ -22,11 +22,13 @@ defmodule Flow.Scale do
   end
 
   def tare do
+    Logger.info("Starting tare...")
     GenServer.cast(__MODULE__, :tare)
   end
 
   def handle_cast(:tare, %{py_pid: pid} = state) do
     :python.call(pid, :scale, :tare, [])
+    Logger.info("Tare complete")
     {:noreply, state}
   end
 

--- a/vendor/scale.py
+++ b/vendor/scale.py
@@ -34,3 +34,6 @@ def teardown():
 
 def get_measurement():
     return scale.get_measurement()
+
+def tare():
+    scale.tare()

--- a/vendor/scale.py
+++ b/vendor/scale.py
@@ -19,6 +19,9 @@ class Scale:
         self.scale.power_up()
         return weight
 
+    def tare(self):
+        self.scale.tare()
+
 class Scale2:
     def get_measurement(self):
         return 123


### PR DESCRIPTION
Allow the kiosk to trigger the scale to tare. This way we can put a button there allowing the user to reset the scale to 0. Currently taring happens only on startup.