### PR TITLE
Add domain updater

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -4,7 +4,12 @@ config :flow,
   api_key: System.get_env("FLOW_API_KEY"),
   screen_provider: Flow.Screen.NullProvider,
   socket_url: nil,
-  monitors: []
+  monitors: [],
+  digital_ocean: [
+    api_token: System.get_env("DIGITAL_OCEAN_API_TOKEN"),
+    domain: "jutonz.com",
+    record_id: "134052056"
+  ]
 
 config :logger,
   backends: [:console, Sentry.LoggerBackend]

--- a/lib/flow/application.ex
+++ b/lib/flow/application.ex
@@ -9,12 +9,13 @@ defmodule Flow.Application do
     import Supervisor.Spec, warn: false
 
     children = [
+      {Finch, name: FlowFinch},
+      Flow.DomainUpdater,
       Flow.FlowSupervisor,
       Flow.HumidityManager,
       Flow.HumidityMonitor,
       Flow.Screen,
-      worker(Flow.Backend, []),
-      {Finch, name: FlowFinch}
+      worker(Flow.Backend, [])
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/flow/domain_updater.ex
+++ b/lib/flow/domain_updater.ex
@@ -1,0 +1,58 @@
+defmodule Flow.DomainUpdater do
+  require Logger
+  use GenServer
+
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args, name: __MODULE__)
+  end
+
+  def init(_args) do
+    if disabled?() do
+      Logger.info("No DigitalOcean API key configured. Skipping DomainUpdater.")
+      :ignore
+    else
+      initial_state = %{
+        domain: config(:domain),
+        record_id: config(:record_id)
+      }
+
+      {:ok, initial_state, {:continue, nil}}
+    end
+  end
+
+  def handle_continue(nil, state) do
+    schedule_checkin()
+    {:noreply, state}
+  end
+
+  @check_every 1000 * 60 * 60
+  defp schedule_checkin do
+    Process.send_after(self(), :update_domain, @check_every)
+  end
+
+  def handle_info(:update_domain, state) do
+    with {:ok, ip} <- Homepage.whatismyip(),
+         {:ok, domain_record} <- update_domain_record(state, ip) do
+      Logger.info("Updated domain record: #{inspect(domain_record)}")
+    else
+      error ->
+        Logger.warn("An error occurred updating the domain: #{inspect(error)}")
+    end
+
+    schedule_checkin()
+    {:noreply, state}
+  end
+
+  defp update_domain_record(%{domain: domain, record_id: record_id}, ip) do
+    DigitalOcean.update_domain_record(domain, record_id, %{"data" => ip})
+  end
+
+  defp disabled? do
+    token = config(:api_token)
+    token == nil || token == ""
+  end
+
+  defp config(config) do
+    Application.fetch_env!(:flow, :digital_ocean) |> Keyword.fetch!(config)
+  end
+end

--- a/lib/flow/humidity_monitor.ex
+++ b/lib/flow/humidity_monitor.ex
@@ -34,8 +34,14 @@ defmodule Flow.HumidityMonitor do
   end
 
   def handle_info(:check, %{awair_ip: ip} = state) do
-    {:ok, humidity} = Awair.humidity(ip)
-    HumidityManager.humidity_callback(humidity)
+    case Awair.humidity(ip) do
+      {:ok, humidity} ->
+        HumidityManager.humidity_callback(humidity)
+
+      error ->
+        Logger.warn("Received bad response from Awair: #{inspect(error)}")
+    end
+
     schedule_checkin()
     {:noreply, state}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule Flow.MixProject do
       app: :flow,
       version: "0.1.0",
       elixir: "~> 1.10",
+      elixirc_paths: elixirc_paths(),
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       dialyzer: [
@@ -45,6 +46,10 @@ defmodule Flow.MixProject do
       {:sentry, "8.0.5"},
       {:websocket_client, "~> 1.4.2"}
     ]
+  end
+
+  def elixirc_paths do
+    ~w[lib vendor test]
   end
 
   def aliases do

--- a/vendor/digital_ocean/client.ex
+++ b/vendor/digital_ocean/client.ex
@@ -1,0 +1,53 @@
+defmodule DigitalOcean.Client do
+  require Logger
+  alias DigitalOcean.Request
+
+  @spec make_request(Request.t()) ::
+    {:ok, map()} |
+    {:error, :bad_response} |
+    {:error, :unauthorized}
+  def make_request(%Request{} = request) do
+    request
+    |> build_request()
+    |> execute()
+    |> respond()
+  end
+
+  @api_base "https://api.digitalocean.com"
+  def build_request(%Request{} = request) do
+    Finch.build(
+      request.method,
+      @api_base <> request.path,
+      Map.to_list(request.headers),
+      encode_body(request.body)
+    )
+  end
+
+  @timeout 5_000
+  def execute(request) do
+    Finch.request(request, FlowFinch, receive_timeout: @timeout)
+  end
+
+  defp respond({:ok, %Finch.Response{body: body, status: status} = response}) do
+    case status do
+      401 ->
+        {:error, :unauthorized}
+      status when status >= 100 and status < 300 ->
+        {:ok, Jason.decode!(body)}
+      _ ->
+      Logger.warn("Received bad response from digitalocean #{inspect(response)}")
+        {:error, :bad_response}
+    end
+  end
+
+  defp respond(response) do
+    Logger.warn("Received bad response from digitalocean #{inspect(response)}")
+    {:error, :bad_response}
+  end
+
+  defp encode_body(nil),
+    do: nil
+
+  defp encode_body(json),
+    do: Jason.encode!(json)
+end

--- a/vendor/digital_ocean/digital_ocean.ex
+++ b/vendor/digital_ocean/digital_ocean.ex
@@ -1,0 +1,7 @@
+defmodule DigitalOcean do
+  defdelegate get_domain_record(domain_name, record_id),
+    to: __MODULE__.Domains
+
+  defdelegate update_domain_record(domain_name, record_id, body),
+    to: __MODULE__.Domains
+end

--- a/vendor/digital_ocean/domains.ex
+++ b/vendor/digital_ocean/domains.ex
@@ -1,0 +1,31 @@
+defmodule DigitalOcean.Domains do
+  alias DigitalOcean.{Client, Request}
+
+  @path "/v2/domains"
+
+  def get_domain_record(domain_name, record_id) do
+    @path <> "/#{domain_name}/records/#{record_id}"
+    |> Request.new(:get)
+    |> Request.authorize()
+    |> Client.make_request()
+    |> respond()
+  end
+
+  def update_domain_record(domain_name, record_id, body) do
+    @path <> "/#{domain_name}/records/#{record_id}"
+    |> Request.new(:put)
+    |> Request.authorize()
+    |> Request.put_header("content-type", "application/json")
+    |> Request.put_body(body)
+    |> Client.make_request()
+    |> respond()
+  end
+
+  defp respond({:ok, response}) do
+    {:ok, Map.get(response, "domain_record")}
+  end
+
+  defp respond(error) do
+    error
+  end
+end

--- a/vendor/digital_ocean/request.ex
+++ b/vendor/digital_ocean/request.ex
@@ -1,0 +1,29 @@
+defmodule DigitalOcean.Request do
+  defstruct [
+    path: nil,
+    method: nil,
+    headers: %{},
+    body: nil,
+  ]
+
+
+  def new(path, method) do
+    %__MODULE__{path: path, method: method}
+  end
+
+  def put_header(request, key, value) do
+    %{request | headers: Map.put(request.headers, key, value)}
+  end
+
+  def put_body(request, body) do
+    %{request | body: body}
+  end
+
+  def authorize(request) do
+    put_header(request, "authorization", "Bearer #{config(:api_token)}")
+  end
+
+  defp config(key) do
+    :flow |> Application.fetch_env!(:digital_ocean) |> Keyword.fetch!(key)
+  end
+end

--- a/vendor/homepage/client.ex
+++ b/vendor/homepage/client.ex
@@ -1,0 +1,64 @@
+defmodule Homepage.Client do
+  require Logger
+  alias Homepage.Request
+
+  @spec make_request(Request.t()) ::
+    {:ok, String.t()} |
+    {:ok, map()} |
+    {:error, :bad_response}
+  def make_request(%Request{} = request) do
+    request
+    |> build_request()
+    |> execute()
+    |> respond()
+  end
+
+  @api_base "https://app.jutonz.com"
+  defp build_request(%Request{} = request) do
+    Finch.build(
+      request.method,
+      @api_base <> request.path,
+      Map.to_list(request.headers),
+      encode_body(request.body)
+    )
+  end
+
+  @timeout 5_000
+  def execute(request) do
+    Finch.request(request, FlowFinch, receive_timeout: @timeout)
+  end
+
+  defp respond({:ok, %Finch.Response{body: body} = response}) do
+    case content_type(response) do
+      :json -> {:ok, Jason.decode!(body)}
+      :text -> {:ok, body}
+    end
+  end
+
+  defp respond(response) do
+    Logger.warn("Received bad response from homepage #{inspect(response)}")
+    {:error, :bad_response}
+  end
+
+  defp encode_body(nil) do
+    nil
+  end
+
+  defp encode_body(json) do
+    Jason.encode!(json)
+  end
+
+  defp content_type(%Finch.Response{} = response) do
+    case get_header(response, "content-type") do
+      "application/json" -> :json
+      _ -> :text
+    end
+  end
+
+  defp get_header(%Finch.Response{headers: headers}, header) do
+    case List.keyfind(headers, header, 0) do
+      {_header, value} -> value
+      _ -> nil
+    end
+  end
+end

--- a/vendor/homepage/client_info.ex
+++ b/vendor/homepage/client_info.ex
@@ -1,0 +1,18 @@
+defmodule Homepage.ClientInfo do
+  alias Homepage.{Client, Request}
+
+  def whatismyip do
+    "/api/whatismyip"
+    |> Request.new(:get)
+    |> Client.make_request()
+    |> respond()
+  end
+
+  defp respond({:ok, ip}) do
+    {:ok, ip}
+  end
+
+  defp respond(error) do
+    error
+  end
+end

--- a/vendor/homepage/homepage.ex
+++ b/vendor/homepage/homepage.ex
@@ -1,0 +1,4 @@
+defmodule Homepage do
+  defdelegate whatismyip,
+    to: __MODULE__.ClientInfo
+end

--- a/vendor/homepage/request.ex
+++ b/vendor/homepage/request.ex
@@ -1,0 +1,12 @@
+defmodule Homepage.Request do
+  defstruct [
+    path: nil,
+    method: nil,
+    headers: %{},
+    body: nil,
+  ]
+
+  def new(path, method) do
+    %__MODULE__{path: path, method: method}
+  end
+end


### PR DESCRIPTION
Makes sure home.jutonz.com always points to the correct IP address.

Internally, this calls `app.jutonz.com/api/whatismyip` to determine the
current IP address, and then talks to DigitalOcean's API to update the
domain record accordingly.

Right now this checks once per hour.